### PR TITLE
Declare binary in package.json (Yarn 2 compatibility)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
         "yaml"
     ],
     "main": "index.js",
+    "bin": {
+      "package-yaml": "./index.js"
+    },
     "scripts": {
         "build": "tsc",
         "watch": "tsc --watch",


### PR DESCRIPTION
Add Yarn 2 PnP compatibility by declaring the binary in `package.json`.

Can be tested like this: 
```sh
# add to a project
yarn add --dev package-yaml@https://github.com/dperetti/package-yaml.git#yarn-compatibility

# Run package-yaml
yaml package-yaml
```